### PR TITLE
fix_integers

### DIFF
--- a/lib/makeup_sql.ex
+++ b/lib/makeup_sql.ex
@@ -1022,7 +1022,7 @@ defmodule MakeupSql do
   single_quote_string = string_like("\'", "\'", [escaped_char], :string_single)
 
   name =
-    ascii_char([?_, ?a..?z, ?A..?Z])
+    ascii_char([?_, ?0..?9, ?a..?z, ?A..?Z])
     |> repeat(ascii_char([?_, ?0..?9, ?a..?z, ?A..?Z]))
     |> token(:name)
 
@@ -1047,7 +1047,6 @@ defmodule MakeupSql do
       keywords,
       built_in,
       operator,
-      integer(min: 1),
       double_quote_string,
       single_quote_string,
       interpolation,

--- a/lib/makeup_sql.ex
+++ b/lib/makeup_sql.ex
@@ -1021,8 +1021,13 @@ defmodule MakeupSql do
   double_quote_string = string_like("\"", "\"", [escaped_char], :string_double)
   single_quote_string = string_like("\'", "\'", [escaped_char], :string_single)
 
+  number =
+    ascii_char([?0..?9])
+    |> repeat(ascii_char([?0..?9]))
+    |> token(:number)
+
   name =
-    ascii_char([?_, ?0..?9, ?a..?z, ?A..?Z])
+    ascii_char([?_, ?a..?z, ?A..?Z])
     |> repeat(ascii_char([?_, ?0..?9, ?a..?z, ?A..?Z]))
     |> token(:name)
 
@@ -1050,6 +1055,7 @@ defmodule MakeupSql do
       double_quote_string,
       single_quote_string,
       interpolation,
+      number,
       name,
       punctuation
     ])


### PR DESCRIPTION
I had a problem with I think this line:
```
order by 1, 2

```
It was due to this function below only accepting 3 element tuples but integer(min: 1) was returning integer.
```
  def __as_sql_language__({ttype, meta, value}) do
    {ttype, Map.put(meta, :language, :sql), value}
  end
```
I was using this file:
https://github.com/dbcli/pgspecial/blob/616f1df83faf7be7ee3e4f07a12cf0cf963ca9a9/dbcommands.sql